### PR TITLE
fix debugging-benchmark repo branch

### DIFF
--- a/src/debugging_framework/resources/requirements_docker.txt
+++ b/src/debugging_framework/resources/requirements_docker.txt
@@ -4,4 +4,4 @@ docker~=7.1.0
 
 # tests4py
 git+https://github.com/martineberlein/Tests4Py
-git+https://github.com/martineberlein/debugging-benchmark@docker
+git+https://github.com/martineberlein/debugging-benchmark@main


### PR DESCRIPTION
container build was failing

it seems that the `docker` branch was deleted